### PR TITLE
Add jasmine reporter

### DIFF
--- a/jasmine-runner.js
+++ b/jasmine-runner.js
@@ -1,0 +1,15 @@
+var Jasmine = require('jasmine');
+var SpecReporter = require('jasmine-spec-reporter');
+var noop = function() {};
+
+var jrunner = new Jasmine();
+
+// remove default reporter logs
+jrunner.configureDefaultReporter({print: noop});
+
+// add jasmine-spec-reporter
+jasmine.getEnv().addReporter(new SpecReporter());
+
+// load jasmine.json configuration   
+jrunner.loadConfigFile();
+jrunner.execute();

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "description": "Reads and creates an index from a json file and offers a search of that index",
   "main": "server.js",
   "scripts": {
-    "test": "jasmine"
+    "test": "node jasmine-runner.js"
   },
   "repository": {
     "type": "git",

--- a/package.json
+++ b/package.json
@@ -27,6 +27,10 @@
     "eslint-config-airbnb": "^10.0.1",
     "eslint-plugin-import": "^1.13.0",
     "eslint-plugin-jsx-a11y": "^2.1.0",
-    "eslint-plugin-react": "^6.1.2"
+    "eslint-plugin-react": "^6.1.2",
+    "jasmine-spec-reporter": "^2.7.0"
+  },
+  "dependencies": {
+    "jasmine": "^2.5.0"
   }
 }


### PR DESCRIPTION
## What does this PR do?

Add jasmine spec reporter to replace default spec reporter for jasmine
## Action Points
- This PR takes care of issue #10.
- Add jasmine spec reporter from npm as development dependency to the project.
- Create a new spec reporter based on jasmine spec reporter.
- Replace test command to use the new reporter instead of the default reporter.
- The spec reporter display all passed jasmine tests while the default jasmine reporter does not do this.
