### PR TITLE
Refactor code and remove unnecessary line

### DIFF
--- a/.jshintrc
+++ b/.jshintrc
@@ -2,12 +2,12 @@
   "boss":      true,
   "node":      true,
   "eqeqeq":    true,
-  "strict":    true,
+  "strict":    "implied",
   "newcap":    false,
   "undef":     true,
   "unused":    true,
   "onecase":   true,
   "lastsemic": true,
   "jasmine":   true,
-  "esversion": "6"
+  "esversion": 6
 }

--- a/.jshintrc
+++ b/.jshintrc
@@ -7,5 +7,7 @@
   "undef":     true,
   "unused":    true,
   "onecase":   true,
-  "lastsemic": true
+  "lastsemic": true,
+  "jasmine":   true,
+  "esversion": "6"
 }

--- a/spec/inverted-index-test.js
+++ b/spec/inverted-index-test.js
@@ -1,4 +1,4 @@
-/* jslint node: true */
+/* jshint node: true */
 
 var fs = require('fs');
 var InvertedIndex = require('../src/inverted-index.js');
@@ -50,8 +50,6 @@ describe('Populate index', function () {
  * Search Index test suite
  */
 describe('Search Index', function() {
-
-
   it('should return an array containing indices of the correct object', function(){
     expect(index.searchIndex('a')).toEqual([[0,1]]);
   });

--- a/spec/inverted-index-test.js
+++ b/spec/inverted-index-test.js
@@ -14,7 +14,7 @@ var booksFileName = index.getFileName(books);
 * Test suite for testing book.json data
 */
 describe('Read book data', function () {
-  it('should not be empty', function () {
+  it('should not be empty', function (done) {
     fs.readFile(books, 'utf8', function (err, data) {
       if (err) throw (err);
       var fileContent = data.replace(/\s+/g, '');
@@ -35,14 +35,13 @@ describe('Populate index', function () {
   });
 
   it('should map string keys to correct objects', function() {
-    expect(index.indexes[booksFileName]['alice']).toEqual([0]);
-    expect(index.indexes[booksFileName]['a']).toEqual([0,1]);
-    expect(index.indexes[booksFileName]['an']).toEqual([1]);
+    expect(index.indexes[booksFileName].alice).toEqual([0]);
+    expect(index.indexes[booksFileName].a).toEqual([0,1]);
+    expect(index.indexes[booksFileName].an).toEqual([1]);
   });
 
-  it('Ensure previous index is not overwritten by a new json file', function(){
+  it('Ensure previous index is not overwritten by a new json file', function() {
     index.createIndex(pages);
-    pageFileName = index.getFileName(pages);
     expect(index.indexes[booksFileName]).not.toEqual(index.indexes[pages]);
   });
 });
@@ -53,7 +52,7 @@ describe('Populate index', function () {
 describe('Search Index', function() {
 
 
-  it('should return an array containing indices of the correct object', function() {
+  it('should return an array containing indices of the correct object', function(){
     expect(index.searchIndex('a')).toEqual([[0,1]]);
   });
 

--- a/spec/inverted-index-test.js
+++ b/spec/inverted-index-test.js
@@ -5,20 +5,16 @@ var InvertedIndex = require('../src/inverted-index.js');
 
 var books = 'jasmine/books.json';
 var pages = 'jasmine/pages.json';
-var emptyFile = 'jasmine/inv-file.json';
+var index = new InvertedIndex();
+index.createIndex(pages);
+index.createIndex(books);
+var booksFileName = index.getFileName(books);
 
-
-beforeAll(function(){
-  index = new InvertedIndex();
-  index.createIndex(pages);
-  index.createIndex(books);
-  booksFileName = index.getFileName(books);
-});
 /**
 * Test suite for testing book.json data
 */
-describe ('Read book data', function () {
-  it ('should not be empty', function () {
+describe('Read book data', function () {
+  it('should not be empty', function () {
     fs.readFile(books, 'utf8', function (err, data) {
       if (err) throw (err);
       var fileContent = data.replace(/\s+/g, '');
@@ -31,7 +27,7 @@ describe ('Read book data', function () {
 /**
  * Populate index test suite
  */
-describe ('Populate index', function () {
+describe('Populate index', function () {
   it('should create a new index when a file has been read', function () {
     expect(index.indexes).not.toBe({});
     expect(typeof index.indexes[booksFileName]).toBe('object');
@@ -54,7 +50,7 @@ describe ('Populate index', function () {
 /**
  * Search Index test suite
  */
-describe ('Search Index', function() {
+describe('Search Index', function() {
 
 
   it('should return an array containing indices of the correct object', function() {

--- a/src/inverted-index.js
+++ b/src/inverted-index.js
@@ -1,6 +1,3 @@
-/* jslint node: true */
-'use strict';
-
 const fs = require('fs');
 
 module.exports = class InvertedIndex {
@@ -18,7 +15,7 @@ module.exports = class InvertedIndex {
    * Create index
    *
    * CreateIndex takes in a string file path, indexes the file and stores it
-   * 
+   *
    * @param  {String} filePath path to the file
    * @return {void}
    */
@@ -28,10 +25,6 @@ module.exports = class InvertedIndex {
 
     if (fileContent.replace(/\s+/g, '').length === 0) {
       throw new Error('file has no content');
-    }
-
-    if (this.indexName.indexOf(fileName) < 0) {
-      this.indexName.push(fileName);
     }
 
     this.indexFileContent[fileName] = fileContent;
@@ -47,11 +40,10 @@ module.exports = class InvertedIndex {
    * @return {Object | String} index object of the file or a message indicating
    * the no index exists
    */
-  getIndex(term) {
-    const filename = term;
+  getIndex(filename) {
     const fileIndexName = this.getFileName(filename);
 
-    if (this.indexName.indexOf(fileIndexName) < 0) {
+    if (!Object.hasOwnProperty.call(this.indexes, fileIndexName)) {
       return 'No index availabale for this file';
     }
 
@@ -76,13 +68,13 @@ module.exports = class InvertedIndex {
 
     this.flattenSearchTerm(term);
 
-    if (this.indexName.indexOf(indexFileName) >= 0) {
+    if (Object.hasOwnProperty.call(this.indexes, indexFileName)) {
       this.setLastSearchedFile(indexFileName);
       this.populateSearchResult(indexFileName);
     } else {
       if (this.lastSearchedFile === '') {
-        const indexNameLength = this.indexName.length;
-        this.setLastSearchedFile(this.indexName[indexNameLength - 1]);
+        const indexNameLength = Object.keys(this.indexes).length;
+        this.setLastSearchedFile(Object.keys(this.indexes)[indexNameLength - 1]);
       }
       this.populateSearchResult(this.lastSearchedFile);
     }
@@ -100,8 +92,7 @@ module.exports = class InvertedIndex {
    */
   getFileName(path) {
     const pathArray = path.split('/');
-    const arrayLength = pathArray.length;
-    return pathArray[arrayLength - 1];
+    return pathArray[pathArray.length - 1];
   }
 
   /**
@@ -113,7 +104,6 @@ module.exports = class InvertedIndex {
    * @return {Object}          index object for the file content
    */
   parseFileContent(fileName) {
-    let fileIndex = {};
     const objectCount = {};
     const fileContent = this.indexFileContent[fileName];
     const fileJson = JSON.parse(fileContent);
@@ -122,17 +112,13 @@ module.exports = class InvertedIndex {
     Object.keys(fileJson).forEach((key) => {
       const title = this.tokenize(fileJson[key].title);
       const text = this.tokenize(fileJson[key].text);
-      const allContent = title.concat(text);
-      const uniqueContent = this.uniqueValues(allContent);
+      const uniqueContent = this.uniqueValues(title.concat(text));
 
-      objectCount[counter] = {};
       objectCount[counter] = uniqueContent;
       counter++;
     });
 
-    fileIndex = this.createFileIndex(objectCount);
-
-    return fileIndex;
+    return this.createFileIndex(objectCount);
   }
 
   /**
@@ -169,9 +155,7 @@ module.exports = class InvertedIndex {
    * @return {Array}
    */
   tokenize(terms) {
-    const termWithoutPunct = this.sanitize(terms);
-    const termArray = termWithoutPunct.split(/\s+/g);
-    return termArray;
+    return this.sanitize(terms).split(/\s+/g);
   }
 
   /**
@@ -230,10 +214,8 @@ module.exports = class InvertedIndex {
    * @return {void}
    */
   populateSearchResult(indexName) {
-    const objectKeys = Object.keys(this.indexes[indexName]);
-
     this.searchTerms.forEach((val) => {
-      if (objectKeys.indexOf(val) >= 0) {
+      if (Object.hasOwnProperty.call(this.indexes[indexName], val)) {
         this.searchResult.push(this.indexes[indexName][val]);
       } else {
         this.searchResult.push([]);


### PR DESCRIPTION
## What does this PR do?

Removes unnecessary lines of code to make the code look cleaner and be more efficient.
## Action Points
- This PR takes care of issue #13.
- Remove `beforeAll()` from the jasmine test as the initialization of the classes can happen without it.
- Remove `use strict` from `invertedIndex` class, JavaScript uses strict es6 rules when the class keyword is used to define a class.
- Remove `indexName` object as it is a redundancy. The purpose it serves can be achieved without it.
- Remove unnecessary variable declarations.
