### PR TITLE
Remove throw error from try-catch block

### DIFF
--- a/spec/inverted-index-test.js
+++ b/spec/inverted-index-test.js
@@ -36,7 +36,7 @@ describe('Create Index', function(){
 
   it('should have a valid JSON array', function(){
     // test for empty array
-    expect(function(){index.createIndex(empty_array)}).toThrowError('not a valid json array');
+    expect(index.createIndex(empty_array)).toBe('not a valid json array');
   });
 });
 

--- a/src/inverted-index.js
+++ b/src/inverted-index.js
@@ -34,7 +34,8 @@ module.exports = class InvertedIndex {
     try {
       this.isEmptyArray(fileContent);
     } catch(err) {
-      throw new Error('not a valid json array');
+      // throw new Error('not a valid json array');
+      return 'not a valid json array';
     }
 
     this.indexFileContent[fileName] = fileContent;


### PR DESCRIPTION
## What does this PR do?

Removes the throw error line from the `createIndex` function. The try-catch block is meant to deal with errors and exceptions and not throw its own error.
## Action points
- This PR takes care of #19.
- Remove `throw new Error()` from try-catch block.
- Change from `throw new Error()` to returning a message alerting the user the file does not contain a valid JSON array.
- Modify test file to test for string instead of checking for a new error.
